### PR TITLE
fix usage of setsid

### DIFF
--- a/Pty.pm
+++ b/Pty.pm
@@ -93,7 +93,7 @@ sub make_slave_controlling_terminal {
   }
 
   # Create a new 'session', lose controlling terminal.
-  if (not POSIX::setsid()) {
+  if (POSIX::setsid() == -1) {
     warn "setsid() failed, strange behavior may result: $!\r\n" if $^W;
   }
 


### PR DESCRIPTION
POSIX::setsid returns -1, not undef on failure:
```
❯ perl -MPOSIX -le 'my $ret = POSIX::setsid; print "$ret: $!"'
-1: Operation not permitted
```