### PR TITLE
Skip winsize test on Solaris and QNX NTO

### DIFF
--- a/t/pty_get_winsize.t
+++ b/t/pty_get_winsize.t
@@ -4,7 +4,13 @@ use strict;
 use warnings;
 
 use Test::More;
-plan tests => 1;
+
+if ( $^O =~ m!^(solaris|nto)$! ) {
+  plan skip_all => 'Problems on Solaris and QNX with this test';
+}
+else {
+  plan tests => 1;
+}
 
 use IO::Pty ();
 


### PR DESCRIPTION
http://matrix.cpantesters.org/?dist=IO-Tty%201.14;os=nto;perl=5.30.1;reports=1

Consistent failure on Solaris and QNX since this test was introduced. Makes installing POE on Solaris a tedious exercise.

Example test failure on Solaris:

http://www.cpantesters.org/cpan/report/023a0e36-74ce-11ea-a57d-61f7d4524f59

example test failure on QNX:

http://www.cpantesters.org/cpan/report/209e03c2-5639-11ea-9066-e374b0ba08e8