### PR TITLE
Make function tests more robust

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -160,7 +160,7 @@ main ()
 #if defined (__stub_$f) || defined (__stub___$f)
 choke me
 #else
-f = $f;
+f = $f ();
 #endif
 
   ;


### PR DESCRIPTION
Actually try calling the function rather than just referencing it. 

This prevents some false-positive function detections, such as seen in #23 where `_getpty()` and `strlcpy()` are detected but are not actually available. This subsequently causes the module to be unloadable.