### PR TITLE
Use $_ to iterate over @ARGV in Makefile.PL

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -16,7 +16,7 @@ use Config qw(%Config);
 my %cfg;
 @cfg{qw(cc ccflags ldflags)} = @Config{qw(cc ccflags ldflags)};
 for my $arg (@ARGV) {
-  if ( /^(CC|CCFLAGS|LDFLAGS)=(.*)/i ) {
+  if ( $arg =~ /^(CC|CCFLAGS|LDFLAGS)=(.*)/i ) {
     $cfg{lc($1)} = $2;
   }
 }


### PR DESCRIPTION
As the default pattern match is used, $arg is not evaluated.  This
fixes warning "Use of uninitialized value $_ in pattern match (m//)
at Makefile.PL line 19".