### PR TITLE
Tty.xs: Do not mark strlcpy as static

### DIFF
--- a/Tty.xs
+++ b/Tty.xs
@@ -186,11 +186,11 @@ mysignal(int sig, mysig_t act)
  * will be copied.  Always NUL terminates (unless siz == 0).
  * Returns strlen(src); if retval >= siz, truncation occurred.
  */
-static size_t
-strlcpy(dst, src, siz)
-        char *dst;
-        const char *src;
-        size_t siz;
+size_t
+strlcpy(
+        char *dst,
+        const char *src,
+        size_t siz)
 {
         register char *d = dst;
         register const char *s = src;


### PR DESCRIPTION
Some libcs e.g. musl do not provide implementation of strlcpy but they
do provide the signature in string.h, if we mark it static here then it
conflicts with the libc define and compiler may warn/error

Fixes
Tty.xs:190:1: error: static declaration of 'strlcpy' follows non-static declaration
strlcpy(                                                                                                                 ^
/mnt/b/yoe/master/build/tmp/work/core2-64-yoe-linux-musl/libio-pty-perl/1.16-r0/recipe-sysroot/usr/include/string.h:86:8: note: previous declaration is here
size_t strlcpy (char *, const char *, size_t);                                                                                  ^

Signed-off-by: Khem Raj <raj.khem@gmail.com>