### PR TITLE
Make function checks more robust within shared libs

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -163,7 +163,8 @@ main ()
 #if defined (__stub_$f) || defined (__stub___$f)
 choke me
 #else
-f = $f ();
+f = $f;
+f();
 #endif
 
   ;
@@ -173,7 +174,7 @@ ESQ
 
   close(TST);
   print "Looking for $f()" . "." x (13-length($f)) . " ";
-  if (system("$cfg{'cc'} $flags $funcs{$f} functest_$f.c > functest_$f.log 2>&1")) {
+  if (system("$cfg{'cc'} $flags -Wl,--no-undefined $funcs{$f} functest_$f.c > functest_$f.log 2>&1")) {
     print "not found.\n";
   } else {
     $define{"-DHAVE_\U$f"} = undef;


### PR DESCRIPTION
Previous attempt to error at link like was with

https://github.com/toddr/IO-Tty/commit/1747cdf9f98cfd3aada9bf6c09f9d46297e18a5e

this however causes issues with newer clang where it detects the assignment as -Wint-conversion warning which is treated at error and builds with clang fail. So this is an attempt to instruct linker explicitly to error out if the symbol is not found during link time when building a shared library, this fixes both the problems as reported in

https://github.com/toddr/IO-Tty/issues/23

as well as

https://github.com/toddr/IO-Tty/pull/33#issuecomment-1260147256